### PR TITLE
feat: Add confidence score for Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,6 +127,6 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.google.android.gms:play-services-mlkit-text-recognition:18.0.0'
+  implementation 'com.google.android.gms:play-services-mlkit-text-recognition:18.0.2'
 
 }

--- a/android/src/main/java/com/reactnativemlkitocr/MlkitOcrModule.kt
+++ b/android/src/main/java/com/reactnativemlkitocr/MlkitOcrModule.kt
@@ -88,6 +88,7 @@ class MlkitOcrModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
           e.putString("text", element.text)
           e.putMap("bounding", getCoordinates(element.boundingBox))
           e.putArray("cornerPoints", getCornerPoints(element.cornerPoints))
+          e.putString("confidence", element.confidence.toString())
           lineElements.pushMap(e)
         }
         val l: WritableMap = Arguments.createMap()
@@ -96,6 +97,7 @@ class MlkitOcrModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         l.putMap("bounding", lCoordinates)
         l.putArray("elements", lineElements)
         l.putArray("cornerPoints", getCornerPoints(line.cornerPoints))
+        l.putString("confidence", line.confidence.toString())
 
         blockElements.pushMap(l)
       }


### PR DESCRIPTION
This was released on the 18.0.1:
https://developers.google.com/ml-kit/release-notes?hl=en#august_16_2022
It does not seem to exist on iOS for now